### PR TITLE
refactor(safemap): Rename NewMap to NewSafeMap and update related tests

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -63,7 +63,7 @@ var data = struct {
 }
 
 func Benchmark_Single_Get_SafeMap(b *testing.B) {
-	m, _ := NewMap[string, string](HashStrKeyFunc())
+	m, _ := NewSafeMap[string, string](HashStrKeyFunc())
 	m.Set(data.key, data.val)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -99,7 +99,7 @@ func Benchmark_Single_Get_SingleRwLock(b *testing.B) {
 }
 
 func Benchmark_Single_Set_SafeMap(b *testing.B) {
-	m, _ := NewMap[string, string](HashStrKeyFunc())
+	m, _ := NewSafeMap[string, string](HashStrKeyFunc())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		m.Set(data.key, data.val)
@@ -131,7 +131,7 @@ func Benchmark_Single_Set_SingleRwLock(b *testing.B) {
 }
 
 func Benchmark_Concurrent_Get_SafeMap(b *testing.B) {
-	m, _ := NewMap[string, string](HashStrKeyFunc())
+	m, _ := NewSafeMap[string, string](HashStrKeyFunc())
 	ch := make(chan struct{}, b.N)
 	for i := 0; i < b.N; i++ {
 		go func() {
@@ -187,7 +187,7 @@ func Benchmark_Concurrent_Get_SingleRwLock(b *testing.B) {
 }
 
 func Benchmark_Concurrent_Set_SafeMap(b *testing.B) {
-	m, _ := NewMap[string, string](HashStrKeyFunc())
+	m, _ := NewSafeMap[string, string](HashStrKeyFunc())
 	ch := make(chan struct{}, b.N)
 	for i := 0; i < b.N; i++ {
 		go func(n int) {
@@ -243,7 +243,7 @@ func Benchmark_Concurrent_Set_SingleRwLock(b *testing.B) {
 }
 
 func Benchmark_Bucket1_Get_SafeMap(b *testing.B) {
-	m := NewStringMap[string, string](WithBuckets[string](1))
+	m := NewSafeMapString[string, string](WithBuckets[string](1))
 	ch := make(chan struct{}, b.N)
 	for i := 0; i < b.N; i++ {
 		go func(n int) {
@@ -257,7 +257,7 @@ func Benchmark_Bucket1_Get_SafeMap(b *testing.B) {
 }
 
 func Benchmark_Bucket2_Get_SafeMap(b *testing.B) {
-	m := NewStringMap[string, string](WithBuckets[string](2))
+	m := NewSafeMapString[string, string](WithBuckets[string](2))
 	ch := make(chan struct{}, b.N)
 	for i := 0; i < b.N; i++ {
 		go func(n int) {
@@ -271,7 +271,7 @@ func Benchmark_Bucket2_Get_SafeMap(b *testing.B) {
 }
 
 func Benchmark_Bucket3_Get_SafeMap(b *testing.B) {
-	m := NewStringMap[string, string](WithBuckets[string](3))
+	m := NewSafeMapString[string, string](WithBuckets[string](3))
 	ch := make(chan struct{}, b.N)
 	for i := 0; i < b.N; i++ {
 		go func(n int) {
@@ -285,7 +285,7 @@ func Benchmark_Bucket3_Get_SafeMap(b *testing.B) {
 }
 
 func Benchmark_Bucket4_Get_SafeMap(b *testing.B) {
-	m := NewStringMap[string, string](WithBuckets[string](4))
+	m := NewSafeMapString[string, string](WithBuckets[string](4))
 	ch := make(chan struct{}, b.N)
 	for i := 0; i < b.N; i++ {
 		go func(n int) {
@@ -299,7 +299,7 @@ func Benchmark_Bucket4_Get_SafeMap(b *testing.B) {
 }
 
 func Benchmark_Bucket5_Get_SafeMap(b *testing.B) {
-	m := NewStringMap[string, string](WithBuckets[string](5))
+	m := NewSafeMapString[string, string](WithBuckets[string](5))
 	ch := make(chan struct{}, b.N)
 	for i := 0; i < b.N; i++ {
 		go func(n int) {
@@ -313,7 +313,7 @@ func Benchmark_Bucket5_Get_SafeMap(b *testing.B) {
 }
 
 func Benchmark_Bucket6_Get_SafeMap(b *testing.B) {
-	m := NewStringMap[string, string](WithBuckets[string](6))
+	m := NewSafeMapString[string, string](WithBuckets[string](6))
 	ch := make(chan struct{}, b.N)
 	for i := 0; i < b.N; i++ {
 		go func(n int) {
@@ -327,7 +327,7 @@ func Benchmark_Bucket6_Get_SafeMap(b *testing.B) {
 }
 
 func Benchmark_Bucket7_Get_SafeMap(b *testing.B) {
-	m := NewStringMap[string, string](WithBuckets[string](7))
+	m := NewSafeMapString[string, string](WithBuckets[string](7))
 	ch := make(chan struct{}, b.N)
 	for i := 0; i < b.N; i++ {
 		go func(n int) {
@@ -341,7 +341,7 @@ func Benchmark_Bucket7_Get_SafeMap(b *testing.B) {
 }
 
 func Benchmark_Bucket8_Get_SafeMap(b *testing.B) {
-	m := NewStringMap[string, string](WithBuckets[string](8))
+	m := NewSafeMapString[string, string](WithBuckets[string](8))
 	ch := make(chan struct{}, b.N)
 	for i := 0; i < b.N; i++ {
 		go func(n int) {
@@ -355,7 +355,7 @@ func Benchmark_Bucket8_Get_SafeMap(b *testing.B) {
 }
 
 func Benchmark_Bucket9_Get_SafeMap(b *testing.B) {
-	m := NewStringMap[string, string](WithBuckets[string](9))
+	m := NewSafeMapString[string, string](WithBuckets[string](9))
 	ch := make(chan struct{}, b.N)
 	for i := 0; i < b.N; i++ {
 		go func(n int) {

--- a/map.go
+++ b/map.go
@@ -62,7 +62,7 @@ type safeMap[K comparable, V any] struct {
 	*options[K]
 }
 
-// NewMap creates a new thread-safe, generic map with configurable options.
+// NewSafeMap creates a new thread-safe, generic map with configurable options.
 //
 // The function takes a variadic number of option functions that can customize
 // the map's behavior. It supports different key and value types through Go's
@@ -78,14 +78,14 @@ type safeMap[K comparable, V any] struct {
 // Example:
 //
 //	// Create a default string-to-int safe map
-//	m, err := NewMap[string, int]()
+//	m, err := NewSafeMap[string, int]()
 //
 //	// Create a map with custom bucket count
-//	m, err := NewMap[string, int](WithBucketCount(8))
+//	m, err := NewSafeMap[string, int](WithBucketCount(8))
 //
 // The function initializes a map with multiple buckets to improve
 // concurrent access performance by reducing lock contention.
-func NewMap[K comparable, V any](options ...OptFunc[K]) (SafeMap[K, V], error) {
+func NewSafeMap[K comparable, V any](options ...OptFunc[K]) (SafeMap[K, V], error) {
 	opt, err := loadOpts(options...)
 	if err != nil {
 		return nil, err
@@ -104,22 +104,22 @@ func NewMap[K comparable, V any](options ...OptFunc[K]) (SafeMap[K, V], error) {
 	return m, nil
 }
 
-// NewStringMap returns a new string generic key SafeMap
-func NewStringMap[K ~string, V any](options ...OptFunc[K]) SafeMap[K, V] {
+// NewSafeMapString returns a new string generic key SafeMap
+func NewSafeMapString[K ~string, V any](options ...OptFunc[K]) SafeMap[K, V] {
 	options = append(options, WithHashFunc(func(k K) uint64 { return Hashstr(string(k)) }))
-	m, _ := NewMap[K, V](options...)
+	m, _ := NewSafeMap[K, V](options...)
 	return m
 }
 
-// NewIntegerMap returns a new integer generic key SafeMap
-func NewIntegerMap[K constraints.Integer, V any](options ...OptFunc[K]) SafeMap[K, V] {
+// NewSafeMapInteger returns a new integer generic key SafeMap
+func NewSafeMapInteger[K constraints.Integer, V any](options ...OptFunc[K]) SafeMap[K, V] {
 	options = append(options, WithHashFunc(func(k K) uint64 {
 		if k < 0 {
 			k = -k
 		}
 		return uint64(k)
 	}))
-	m, _ := NewMap[K, V](options...)
+	m, _ := NewSafeMap[K, V](options...)
 	return m
 }
 

--- a/map_test.go
+++ b/map_test.go
@@ -9,26 +9,26 @@ import (
 )
 
 func TestNewSafeMap(t *testing.T) {
-	_, err := NewMap[string, string]()
+	_, err := NewSafeMap[string, string]()
 	assert.ErrorIs(t, err, ErrMissingHashFunc)
 
-	m, err := NewMap[string, string](HashStrKeyFunc())
+	m, err := NewSafeMap[string, string](HashStrKeyFunc())
 	assert.Nil(t, err)
 	assert.NotNil(t, m)
 }
 
 func TestNewStringSafeMap(t *testing.T) {
-	m := NewStringMap[string, int]()
+	m := NewSafeMapString[string, int]()
 	assert.NotNil(t, m)
 }
 
 func TestNewInteger(t *testing.T) {
-	m := NewIntegerMap[int, string]()
+	m := NewSafeMapInteger[int, string]()
 	assert.NotNil(t, m)
 }
 
 func TestInteger(t *testing.T) {
-	m := NewIntegerMap[int, int]()
+	m := NewSafeMapInteger[int, int]()
 	m.Set(-1, 1)
 	val, loaded := m.GetOrSet(-1, 1)
 	assert.True(t, loaded)
@@ -36,7 +36,7 @@ func TestInteger(t *testing.T) {
 }
 
 func TestSafeMapLen(t *testing.T) {
-	safeMap, _ := NewMap[string, int](HashStrKeyFunc())
+	safeMap, _ := NewSafeMap[string, int](HashStrKeyFunc())
 	n := 1000000
 	wg := sync.WaitGroup{}
 	for i := 0; i < n; i++ {
@@ -66,7 +66,7 @@ func TestSafeMapLen(t *testing.T) {
 
 func TestGetAndDelete(t *testing.T) {
 	const N = 50000
-	m, _ := NewMap[string, string](HashStrKeyFunc())
+	m, _ := NewSafeMap[string, string](HashStrKeyFunc())
 	for i := 0; i < N; i++ {
 		m.Set(strconv.Itoa(i), "hello")
 	}
@@ -95,7 +95,7 @@ func TestGetAndDelete(t *testing.T) {
 }
 
 func TestGetOrSet(t *testing.T) {
-	m, _ := NewMap[string, int](WithHashFunc(func(s string) uint64 { return Hashstr(s) }))
+	m, _ := NewSafeMap[string, int](WithHashFunc(func(s string) uint64 { return Hashstr(s) }))
 
 	const N = 300
 	for i := 0; i < N; i++ {
@@ -121,7 +121,7 @@ func TestGetOrSet(t *testing.T) {
 }
 
 func TestIsEmpty(t *testing.T) {
-	m, _ := NewMap[string, string](WithHashFunc(func(s string) uint64 { return Hashstr(s) }))
+	m, _ := NewSafeMap[string, string](WithHashFunc(func(s string) uint64 { return Hashstr(s) }))
 
 	// Test empty map
 	assert.True(t, m.IsEmpty())
@@ -136,7 +136,7 @@ func TestIsEmpty(t *testing.T) {
 }
 
 func TestRange(t *testing.T) {
-	m, _ := NewMap[string, int](WithHashFunc(func(s string) uint64 { return Hashstr(s) }))
+	m, _ := NewSafeMap[string, int](WithHashFunc(func(s string) uint64 { return Hashstr(s) }))
 
 	// Populate the map
 	testData := map[string]int{
@@ -168,7 +168,7 @@ func TestRange(t *testing.T) {
 }
 
 func TestConcurrentOperations(t *testing.T) {
-	m, _ := NewMap[string, int](WithHashFunc(func(s string) uint64 { return Hashstr(s) }))
+	m, _ := NewSafeMap[string, int](WithHashFunc(func(s string) uint64 { return Hashstr(s) }))
 
 	// Concurrent set and get operations
 	wg := sync.WaitGroup{}
@@ -190,7 +190,7 @@ func TestConcurrentOperations(t *testing.T) {
 }
 
 func TestClear(t *testing.T) {
-	m, _ := NewMap[string, int](WithHashFunc(func(s string) uint64 { return Hashstr(s) }))
+	m, _ := NewSafeMap[string, int](WithHashFunc(func(s string) uint64 { return Hashstr(s) }))
 	for i := 0; i < 1000; i++ {
 		m.Set(strconv.Itoa(i), i)
 	}
@@ -199,7 +199,7 @@ func TestClear(t *testing.T) {
 }
 
 func BenchmarkSafeMapClear(b *testing.B) {
-	m, _ := NewMap[string, int](WithHashFunc(func(s string) uint64 { return Hashstr(s) }))
+	m, _ := NewSafeMap[string, int](WithHashFunc(func(s string) uint64 { return Hashstr(s) }))
 	for i := 0; i < 1000; i++ {
 		m.Set(strconv.Itoa(i), i)
 	}

--- a/sync_map.go
+++ b/sync_map.go
@@ -11,6 +11,13 @@ type SyncMap[K comparable, V any] struct {
 	p sync.Map
 }
 
+// NewSyncMap returns a new SyncMap
+func NewSyncMap[K comparable, V any]() *SyncMap[K, V] {
+	return &SyncMap[K, V]{
+		p: sync.Map{},
+	}
+}
+
 // Get returns key's value, and exists.
 //
 // Same as sync.Map.Load

--- a/sync_map_test.go
+++ b/sync_map_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSyncMap(t *testing.T) {
-	m := SyncMap[string, string]{}
+	m := NewSyncMap[string, string]()
 	value, ok := m.Get("key")
 	assert.False(t, ok)
 	assert.Equal(t, "", value)
@@ -34,7 +34,7 @@ func TestSyncMap(t *testing.T) {
 }
 
 func TestSyncMapPointerInt(t *testing.T) {
-	m := SyncMap[int, *int]{}
+	m := NewSyncMap[int, *int]()
 
 	value, ok := m.Get(1)
 	assert.False(t, ok)
@@ -59,7 +59,7 @@ func TestSyncMapPointerInt(t *testing.T) {
 }
 
 func TestSyncMapGet(t *testing.T) {
-	m := &SyncMap[string, int]{}
+	m := NewSyncMap[string, int]()
 
 	// Test getting non-existent key
 	val, exists := m.Get("key1")
@@ -82,7 +82,7 @@ func TestSyncMapGet(t *testing.T) {
 }
 
 func TestSyncMapSet(t *testing.T) {
-	m := &SyncMap[string, int]{}
+	m := NewSyncMap[string, int]()
 
 	// Test setting a value
 	m.Set("key1", 42)
@@ -109,7 +109,7 @@ func TestSyncMapDelete(t *testing.T) {
 	m := &SyncMap[string, int]{}
 
 	// Test deleting non-existent key
-	m.Delete("key1") // Should not panic
+	m.Delete("key1")
 
 	// Test deleting existing key
 	m.Set("key1", 42)
@@ -124,7 +124,7 @@ func TestSyncMapDelete(t *testing.T) {
 }
 
 func TestSyncMapGetAndDelete(t *testing.T) {
-	m := &SyncMap[string, int]{}
+	m := NewSyncMap[string, int]()
 
 	// Test getting and deleting non-existent key
 	val, loaded := m.GetAndDelete("key1")
@@ -184,7 +184,7 @@ func TestSyncMapRange(t *testing.T) {
 }
 
 func TestSyncMapGetOrSet(t *testing.T) {
-	m := &SyncMap[string, int]{}
+	m := NewSyncMap[string, int]()
 
 	// Test GetOrSet for non-existent key
 	val, loaded := m.GetOrSet("key1", 42)
@@ -206,7 +206,7 @@ func TestSyncMapGetOrSet(t *testing.T) {
 }
 
 func TestSyncMapSwap(t *testing.T) {
-	m := &SyncMap[string, int]{}
+	m := NewSyncMap[string, int]()
 
 	// Test Swap for non-existent key
 	prev, loaded := m.Swap("key1", 42)
@@ -228,7 +228,7 @@ func TestSyncMapSwap(t *testing.T) {
 }
 
 func TestSyncMapCompareAndDelete(t *testing.T) {
-	m := &SyncMap[string, int]{}
+	m := NewSyncMap[string, int]()
 
 	// Test CompareAndDelete for non-existent key
 	deleted := m.CompareAndDelete("key1", 42)
@@ -257,7 +257,7 @@ func TestSyncMapCompareAndDelete(t *testing.T) {
 }
 
 func TestSyncMapCompareAndSwap(t *testing.T) {
-	m := &SyncMap[string, int]{}
+	m := NewSyncMap[string, int]()
 
 	// Test CompareAndSwap for non-existent key
 	swapped := m.CompareAndSwap("key1", 0, 42)
@@ -287,7 +287,7 @@ func TestSyncMapCompareAndSwap(t *testing.T) {
 
 // Concurrent Tests
 func TestSyncMapConcurrentOperations(t *testing.T) {
-	m := &SyncMap[string, int]{}
+	m := NewSyncMap[string, int]()
 
 	// Concurrent writes
 	var wg sync.WaitGroup


### PR DESCRIPTION
- Updated all instances of NewMap to NewSafeMap in benchmark and test files for consistency.
- Renamed NewStringMap and NewIntegerMap to NewSafeMapString and NewSafeMapInteger respectively.